### PR TITLE
Feat 28 update docdb

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,5 +2,6 @@
 exclude =
     .git,
     __pycache__,
-    build
+    build,
+    env
 max-complexity = 10

--- a/.gitignore
+++ b/.gitignore
@@ -102,7 +102,7 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-.env
+env
 .venv
 env/
 venv/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ dev = [
 ]
 full = [
     'aind-alert-utils',
-    'aind-data-schema-models>=0.3.2'
+    'aind-data-schema-models>=0.3.2',
+    'aind-data-schema>=1.2.0,<1.3.0'
 ]
 
 [tool.setuptools.packages.find]
@@ -83,5 +84,5 @@ line_length = 79
 profile = "black"
 
 [tool.interrogate]
-exclude = ["setup.py", "docs", "build"]
+exclude = ["setup.py", "docs", "build", "env"]
 fail-under = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ dev = [
 full = [
     'aind-alert-utils',
     'aind-data-schema-models>=0.3.2',
-    'aind-data-schema>=1.2.0,<1.3.0'
+    'aind-data-schema>=1.2.0,<1.3.0',
+    'aind-data-access-api[docdb]>=1.0.0'
 ]
 
 [tool.setuptools.packages.find]

--- a/src/aind_codeocean_pipeline_monitor/job.py
+++ b/src/aind_codeocean_pipeline_monitor/job.py
@@ -3,12 +3,18 @@
 import json
 import logging
 import re
-from datetime import datetime
-from typing import Dict, Optional
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
 from urllib.request import urlopen
 from zoneinfo import ZoneInfo
 
 import requests
+from aind_data_access_api.document_db import MetadataDbClient
+from aind_data_schema.core.metadata import (
+    CORE_FILES,
+    ExternalPlatforms,
+    create_metadata_json,
+)
 
 try:
     from aind_alert_utils.teams import create_body_contents
@@ -25,6 +31,7 @@ from codeocean.data_asset import (
     AWSS3Target,
     ComputationSource,
     DataAsset,
+    DataAssetOrigin,
     DataAssetParams,
     DataAssetState,
     Source,
@@ -145,16 +152,18 @@ class PipelineMonitorJob:
         else:
             return None
 
+    @staticmethod
     def _get_name_and_level_from_data_description(
-        self, computation: Computation
+        core_metadata_json: Dict[str, Dict[str, Any]]
     ) -> Dict[str, Optional[str]]:
         """
-        Attempts to download a data_description file from the 'results' folder
-        and then extracts the 'name' and 'data_level' from that file.
+        Attempts to extract a name and data level from the data_description
+        if the data_description is found.
 
         Parameters
         ----------
-        computation : Computation
+        core_metadata_json : Dict[str, Dict[str, Any]]
+          For example, {"subject": ..., "data_description":...}
 
         Returns
         -------
@@ -163,24 +172,8 @@ class PipelineMonitorJob:
 
         """
 
-        dd_file_name = (
-            self.job_settings.capture_settings.data_description_file_name
-        )
-
-        result_files = self.client.computations.list_computation_results(
-            computation_id=computation.id
-        )
-
-        if dd_file_name in [r.path for r in result_files.items]:
-            download_url = (
-                self.client.computations.get_result_file_download_url(
-                    computation_id=computation.id,
-                    path=dd_file_name,
-                )
-            )
-            with urlopen(download_url.url) as f:
-                contents = f.read().decode("utf-8")
-            data_description = json.loads(contents)
+        if core_metadata_json.get("data_description") is not None:
+            data_description = core_metadata_json.get("data_description")
             return {
                 "name": data_description.get("name"),
                 "data_level": data_description.get("data_level"),
@@ -189,7 +182,9 @@ class PipelineMonitorJob:
             return {"name": None, "data_level": None}
 
     def _get_name(
-        self, computation: Computation, input_data_name: Optional[str]
+        self,
+        input_data_name: Optional[str],
+        core_metadata_jsons: Dict[str, Dict[str, Any]],
     ) -> str:
         """
         Get a data asset name. Will try to use the name from a
@@ -199,14 +194,10 @@ class PipelineMonitorJob:
 
         Parameters
         ----------
-        computation : Computation
-          Uses the computation.id and the code ocean sdk to check if there is
-          a data_description.json file in the results folder. Will attempt to
-          extract the data_asset_name from that file if found. Otherwise, this
-          method will construct a default name using the input data_asset and
-          the current datetime in utc.
         input_data_name : Optional[str]
           Name of the input data asset. The computation only stores the id.
+        core_metadata_jsons : Dict[str, Dict[str, Any]]
+          For example, {"subject": ..., "data_description":...}
 
         Returns
         -------
@@ -226,7 +217,7 @@ class PipelineMonitorJob:
         default_name = f"{input_data_name}_{suffix}_{dt_suffix}"
 
         info_from_file = self._get_name_and_level_from_data_description(
-            computation=computation
+            core_metadata_jsons
         )
         name_from_file = info_from_file.get("name")
         level_from_file = info_from_file.get("data_level")
@@ -259,6 +250,7 @@ class PipelineMonitorJob:
         self,
         monitor_pipeline_response: Computation,
         input_data_name: Optional[str],
+        core_metadata_jsons: Dict[str, Dict[str, Any]],
     ) -> DataAssetParams:
         """
         Build DataAssetParams model from CapturedDataAssetParams and
@@ -270,6 +262,9 @@ class PipelineMonitorJob:
           The Computation from monitor_pipeline_response. If Target is set to
           AWSS3Target, prefix will be overridden with data asset name.
         input_data_name : Optional[str]
+          Name of the input data asset that was converted to a result
+        core_metadata_jsons: Dict[str, Dict[str, Any]]
+          For example, {"subject": ..., "data_description":...}
 
         Returns
         -------
@@ -280,7 +275,7 @@ class PipelineMonitorJob:
             data_asset_name = self.job_settings.capture_settings.name
         else:
             data_asset_name = self._get_name(
-                computation=monitor_pipeline_response,
+                core_metadata_jsons=core_metadata_jsons,
                 input_data_name=input_data_name,
             )
         if self.job_settings.capture_settings.mount is not None:
@@ -312,6 +307,133 @@ class PipelineMonitorJob:
         )
         return data_asset_params
 
+    def _gather_metadata(
+        self, computation: Computation
+    ) -> Dict[str, Dict[str, Any]]:
+        """
+        Gather all the metadata files from the top level results folder into
+        a single dictionary
+        Parameters
+        ----------
+        computation : Computation
+
+        Returns
+        -------
+        Dict[str, Dict[str, Any]]
+          For example, {"subject": ..., "data_description":...}
+
+        """
+        result_files = self.client.computations.list_computation_results(
+            computation_id=computation.id
+        )
+        core_jsons = dict()
+        for core_metadata_name in CORE_FILES:
+            core_metadata_json_name = f"{core_metadata_name}.json"
+            if core_metadata_json_name in [r.path for r in result_files.items]:
+                download_url = (
+                    self.client.computations.get_result_file_download_url(
+                        computation_id=computation.id,
+                        path=core_metadata_json_name,
+                    )
+                )
+                with urlopen(download_url.url) as f:
+                    contents = f.read().decode("utf-8")
+                metadata_contents = json.loads(contents)
+                core_jsons[core_metadata_name] = metadata_contents
+        return core_jsons
+
+    def _update_docdb(
+        self,
+        core_metadata_jsons: Dict[str, Dict[str, Any]],
+        capture_result_response: DataAsset,
+        name: str,
+    ) -> None:
+        """
+        Add a record in DocDB for the newly created Result
+        Parameters
+        ----------
+        core_metadata_jsons : Dict[str, Dict[str, Any]]
+          For example, {"subject": ..., "data_description":...}
+        capture_result_response : DataAsset
+        name : str
+          The name of the data asset.
+
+        Returns
+        -------
+        None
+          Modifies the DocDB Database
+
+        """
+
+        docdb_settings = self.job_settings.capture_settings.docdb_settings
+        capture_result_source = capture_result_response.source_bucket
+        codeocean_id = capture_result_response.id
+        # We only index data assets in AWS for now
+        if capture_result_source is None or (
+            capture_result_source is not None
+            and capture_result_source.external is not True
+        ):
+            bucket = docdb_settings.results_bucket
+            prefix = capture_result_response.id
+        elif (
+            capture_result_source is not None
+            and capture_result_source.external is True
+            and capture_result_source.origin == DataAssetOrigin.AWS
+            and capture_result_source.bucket is not None
+            and capture_result_source.prefix is not None
+        ):
+            bucket = capture_result_source.bucket
+            prefix = capture_result_source.prefix
+        else:
+            raise ValueError(
+                f"Unable to add record to DocDB using "
+                f"{capture_result_response} and {docdb_settings}!"
+            )
+        location = f"s3://{bucket}/{prefix}"
+        last_modified = (
+            datetime.now(tz=timezone.utc).isoformat().replace("+00:00", "Z")
+        )
+        external_links = {ExternalPlatforms.CODEOCEAN.value: [codeocean_id]}
+        metadata = create_metadata_json(
+            name=name,
+            location=location,
+            optional_external_links=external_links,
+            core_jsons=core_metadata_jsons,
+        )
+        if docdb_settings is not None:
+            docdb_client = MetadataDbClient(
+                host=docdb_settings.docdb_api_gateway,
+                database=docdb_settings.docdb_database,
+                collection=docdb_settings.docdb_collection,
+            )
+            # check if record exists
+            filter_query = {"location": location}
+            projection = {"_id": 1, "location": 1, "external_links": 1}
+            records = docdb_client.retrieve_docdb_records(
+                filter_query=filter_query,
+                projection=projection,
+                limit=1,
+                paginate=False,
+            )
+            if len(records) > 0:
+                for record in records:
+                    external_links = set(
+                        record.get("external_links", dict()).get(
+                            ExternalPlatforms.CODEOCEAN, []
+                        )
+                    )
+                    external_links.add(capture_result_response.id)
+                    external_links = sorted(list(external_links))
+                    record["external_links"] = external_links
+                    record["last_modified"] = last_modified
+                    docdb_client.upsert_one_docdb_record(record=record)
+            else:
+                docdb_response = docdb_client.upsert_one_docdb_record(
+                    record=metadata
+                )
+                docdb_response.raise_for_status()
+                logging.info(f"DocDB response: {docdb_response.json()}")
+
     def run_job(self):
         """
         Run pipeline monitor job. If captured_data_asset_params is not
@@ -340,9 +462,13 @@ class PipelineMonitorJob:
             )
             if self.job_settings.capture_settings is not None:
                 logging.info("Capturing result")
+                core_metadata_jsons = self._gather_metadata(
+                    computation=monitor_pipeline_response
+                )
                 data_asset_params = self._build_data_asset_params(
                     monitor_pipeline_response=monitor_pipeline_response,
                     input_data_name=input_data_name,
+                    core_metadata_jsons=core_metadata_jsons,
                 )
                 capture_result_response = (
                     self.client.data_assets.create_data_asset(
@@ -362,6 +488,16 @@ class PipelineMonitorJob:
                     data_asset_id=capture_result_response.id,
                     permissions=self.job_settings.capture_settings.permissions,
                 )
+                if (
+                    self.job_settings.capture_settings.docdb_settings
+                    is not None
+                ):
+                    self._update_docdb(
+                        core_metadata_jsons=core_metadata_jsons,
+                        name=data_asset_params.name,
+                        capture_result_response=capture_result_response,
+                    )
+
             logging.info("Finished job.")
             if self.job_settings.alert_url is not None:
                 message = f"Finished {input_data_name}"

--- a/src/aind_codeocean_pipeline_monitor/models.py
+++ b/src/aind_codeocean_pipeline_monitor/models.py
@@ -24,6 +24,30 @@ from pydantic_core.core_schema import ValidationInfo
 from pydantic_settings import BaseSettings
 
 
+class DocDbSettings(BaseSettings):
+    """Settings needed to add a record to DocDB"""
+
+    docdb_api_gateway: str = Field(
+        default=...,
+        description="DocDB API Gateway",
+    )
+    docdb_database: str = Field(
+        default=...,
+        description="DocDB Database",
+    )
+    docdb_collection: str = Field(
+        default=...,
+        description="DocDB Collection",
+    )
+    results_bucket: str = Field(
+        default=...,
+        description=(
+            "Bucket where Code Ocean stores results. "
+            "This is used to add the location field in the DocDB record."
+        ),
+    )
+
+
 class CaptureSettings(BaseSettings, DataAssetParams):
     """
     Make name and mount fields optional. They will be determined after the
@@ -40,9 +64,8 @@ class CaptureSettings(BaseSettings, DataAssetParams):
     data_description_file_name: Literal["data_description.json"] = Field(
         default="data_description.json",
         description=(
-            "Attempt to create data asset name from this file. We might "
-            "import this from the aind-data-schema package directly in future "
-            "releases."
+            "(DEPRECATED) We are pulling this name from aind-data-schema. "
+            "This field will be removed in a future release."
         ),
     )
     process_name_suffix: Optional[str] = Field(default="processed")
@@ -50,6 +73,14 @@ class CaptureSettings(BaseSettings, DataAssetParams):
     permissions: Permissions = Field(
         default=Permissions(everyone=EveryoneRole.Viewer),
         description="Permissions to assign to capture result.",
+    )
+    docdb_settings: Optional[DocDbSettings] = Field(
+        default=None,
+        description=(
+            "Settings to interface with DocumentDB. "
+            "Allows job to add record immediately after the results folder is "
+            "created in S3."
+        ),
     )
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,9 @@
 """Tests for models module"""
 
 import json
+import os
 import unittest
+from unittest.mock import patch
 
 from codeocean.computation import RunParams
 from codeocean.data_asset import AWSS3Target, Target
@@ -9,8 +11,32 @@ from pydantic import ValidationError
 
 from aind_codeocean_pipeline_monitor.models import (
     CaptureSettings,
+    DocDbSettings,
     PipelineMonitorSettings,
 )
+
+
+class TestDocDbSettings(unittest.TestCase):
+    """Tests for DocDbSettings class."""
+
+    @patch.dict(
+        os.environ,
+        {
+            "DOCDB_API_GATEWAY": "example.com",
+            "DOCDB_DATABASE": "db",
+            "DOCDB_COLLECTION": "coll",
+            "RESULTS_BUCKET": "example_bucket",
+        },
+        clear=True,
+    )
+    def test_construction(self):
+        """Tests settings will pull from env vars"""
+
+        docdb_settings = DocDbSettings()
+        self.assertEqual("example.com", docdb_settings.docdb_api_gateway)
+        self.assertEqual("db", docdb_settings.docdb_database)
+        self.assertEqual("coll", docdb_settings.docdb_collection)
+        self.assertEqual("example_bucket", docdb_settings.results_bucket)
 
 
 class TestsCapturedDataAssetParams(unittest.TestCase):


### PR DESCRIPTION
Closes #28 

- Adds ability to create metadata json file and uploads it to docdb after a new results data asset is created
- Requires AWS role that has permissions to write to DocDB