### PR TITLE
feat: update default permissions to include data admins

### DIFF
--- a/src/aind_codeocean_pipeline_monitor/models.py
+++ b/src/aind_codeocean_pipeline_monitor/models.py
@@ -71,7 +71,14 @@ class CaptureSettings(BaseSettings, DataAssetParams):
     process_name_suffix: Optional[str] = Field(default="processed")
     process_name_suffix_tz: Optional[str] = Field(default="UTC")
     permissions: Permissions = Field(
-        default=Permissions(everyone=EveryoneRole.Viewer),
+        default=Permissions(
+            groups=[
+                GroupPermissions(
+                    group="AIND Data Administrators", role=GroupRole.Owner
+                )
+            ],
+            everyone=EveryoneRole.Viewer,
+        ),
         description="Permissions to assign to capture result.",
     )
     docdb_settings: Optional[DocDbSettings] = Field(

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -9,7 +9,12 @@ from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
 from codeocean import CodeOcean
-from codeocean.components import EveryoneRole, Permissions
+from codeocean.components import (
+    EveryoneRole,
+    GroupPermissions,
+    GroupRole,
+    Permissions,
+)
 from codeocean.computation import (
     Computation,
     ComputationEndStatus,
@@ -1102,7 +1107,14 @@ class TestPipelineMonitorJob(unittest.TestCase):
         self.assertEqual(8, len(captured.output))
         mock_update_permissions.assert_called_once_with(
             data_asset_id="def-123",
-            permissions=Permissions(everyone=EveryoneRole.Viewer),
+            permissions=Permissions(
+                everyone=EveryoneRole.Viewer,
+                groups=[
+                    GroupPermissions(
+                        group="AIND Data Administrators", role=GroupRole.Owner
+                    )
+                ],
+            ),
         )
         mock_gather_metadata.assert_called_once()
         mock_update_docdb.assert_called_once()
@@ -1211,7 +1223,14 @@ class TestPipelineMonitorJob(unittest.TestCase):
 
         mock_update_permissions.assert_called_once_with(
             data_asset_id="def-123",
-            permissions=Permissions(everyone=EveryoneRole.Viewer),
+            permissions=Permissions(
+                everyone=EveryoneRole.Viewer,
+                groups=[
+                    GroupPermissions(
+                        group="AIND Data Administrators", role=GroupRole.Owner
+                    )
+                ],
+            ),
         )
         mock_gather_metadata.assert_called_once()
         mock_update_docdb.assert_called_once()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -53,7 +53,12 @@ class TestsCapturedDataAssetParams(unittest.TestCase):
         expected_model_json = {
             "tags": ["derived, 123456, ecephys"],
             "description": "some data",
-            "permissions": {"everyone": "viewer"},
+            "permissions": {
+                "everyone": "viewer",
+                "groups": [
+                    {"group": "AIND Data Administrators", "role": "owner"}
+                ],
+            },
             "custom_metadata": {"data level": "derived"},
             "data_description_file_name": "data_description.json",
             "process_name_suffix": "processed",
@@ -71,7 +76,12 @@ class TestsCapturedDataAssetParams(unittest.TestCase):
             target=Target(aws=AWSS3Target(bucket="my-bucket", prefix="")),
         )
         expected_model_json = {
-            "permissions": {"everyone": "viewer"},
+            "permissions": {
+                "everyone": "viewer",
+                "groups": [
+                    {"group": "AIND Data Administrators", "role": "owner"}
+                ],
+            },
             "tags": ["derived, 123456, ecephys"],
             "target": {"aws": {"bucket": "my-bucket", "prefix": ""}},
             "process_name_suffix": "processed",
@@ -104,7 +114,12 @@ class TestsPipelineMonitorSettings(unittest.TestCase):
                 "data_description_file_name": "data_description.json",
                 "process_name_suffix": "processed",
                 "process_name_suffix_tz": "UTC",
-                "permissions": {"everyone": "viewer"},
+                "permissions": {
+                    "everyone": "viewer",
+                    "groups": [
+                        {"group": "AIND Data Administrators", "role": "owner"}
+                    ],
+                },
             },
             "computation_polling_interval": 180,
             "data_asset_ready_polling_interval": 10,


### PR DESCRIPTION
- Sets AIND Data Admins as a default owners for captured assets