### PR TITLE
feat: optional CaptureSettings.permissions_token for capture result permissions

### DIFF
--- a/src/aind_codeocean_pipeline_monitor/job.py
+++ b/src/aind_codeocean_pipeline_monitor/job.py
@@ -526,7 +526,17 @@ class PipelineMonitorJob:
                 logging.info(
                     f"wait_for_data_asset_response: {wait_for_data_asset}"
                 )
-                self.client.data_assets.update_permissions(
+                token = self.job_settings.capture_settings.permissions_token
+                client = (
+                    CodeOcean(
+                        domain=self.client.domain,
+                        token=token.get_secret_value(),
+                        retries=self.client.retries,
+                    )
+                    if token is not None
+                    else self.client
+                )
+                client.data_assets.update_permissions(
                     data_asset_id=capture_result_response.id,
                     permissions=self.job_settings.capture_settings.permissions,
                 )

--- a/src/aind_codeocean_pipeline_monitor/models.py
+++ b/src/aind_codeocean_pipeline_monitor/models.py
@@ -19,7 +19,7 @@ from codeocean.data_asset import (  # noqa: F401
     ResultsInfo,
     Target,
 )
-from pydantic import Field, field_validator
+from pydantic import Field, SecretStr, field_validator
 from pydantic_core.core_schema import ValidationInfo
 from pydantic_settings import BaseSettings
 
@@ -87,6 +87,13 @@ class CaptureSettings(BaseSettings, DataAssetParams):
             "Settings to interface with DocumentDB. "
             "Allows job to add record immediately after the results folder is "
             "created in S3."
+        ),
+    )
+    permissions_token: Optional[SecretStr] = Field(
+        default=None,
+        description=(
+            "Optional Code Ocean token used to update capture result "
+            "permissions. If None, will use the client from the main job."
         ),
     )
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -37,6 +37,7 @@ from codeocean.data_asset import (
     Target,
 )
 from codeocean.folder import FolderItem
+from pydantic import SecretStr
 from requests import Response
 from requests.exceptions import HTTPError
 
@@ -85,6 +86,12 @@ class TestPipelineMonitorJob(unittest.TestCase):
                 ),
             ),
         )
+        capture_settings_with_token = capture_results_settings.model_copy(
+            deep=True
+        )
+        capture_settings_with_token.capture_settings.permissions_token = (
+            SecretStr("permissions_token")
+        )
         capture_settings_with_alert = capture_results_settings.model_copy(
             deep=True
         )
@@ -102,11 +109,17 @@ class TestPipelineMonitorJob(unittest.TestCase):
         capture_job = PipelineMonitorJob(
             job_settings=capture_results_settings, client=co_client
         )
+        capture_job_with_permissions_token = PipelineMonitorJob(
+            job_settings=capture_settings_with_token, client=co_client
+        )
         capture_job_with_alert = PipelineMonitorJob(
             job_settings=capture_settings_with_alert, client=co_client
         )
         cls.no_capture_job = no_capture_job
         cls.capture_job = capture_job
+        cls.capture_job_with_permissions_token = (
+            capture_job_with_permissions_token
+        )
         cls.capture_job_with_alert = capture_job_with_alert
         cls.internal_server_error = internal_server_error
         cls.expected_data_description = expected_data_description
@@ -1029,6 +1042,7 @@ class TestPipelineMonitorJob(unittest.TestCase):
     )
     @patch("codeocean.data_asset.DataAssets.create_data_asset")
     @patch("codeocean.computation.Computations.run_capsule")
+    @patch("aind_codeocean_pipeline_monitor.job.CodeOcean")
     @patch("codeocean.data_asset.DataAssets.update_permissions")
     @patch(
         "aind_codeocean_pipeline_monitor.job.PipelineMonitorJob._update_docdb"
@@ -1039,6 +1053,7 @@ class TestPipelineMonitorJob(unittest.TestCase):
         mock_datetime: MagicMock,
         mock_update_docdb: MagicMock,
         mock_update_permissions: MagicMock,
+        mock_permissions_client: MagicMock,
         mock_run_capsule: MagicMock,
         mock_create_data_asset: MagicMock,
         mock_gather_metadata: MagicMock,
@@ -1105,6 +1120,134 @@ class TestPipelineMonitorJob(unittest.TestCase):
             self.capture_job.run_job()
 
         self.assertEqual(8, len(captured.output))
+        mock_permissions_client.assert_not_called()
+        mock_update_permissions.assert_called_once_with(
+            data_asset_id="def-123",
+            permissions=Permissions(
+                everyone=EveryoneRole.Viewer,
+                groups=[
+                    GroupPermissions(
+                        group="AIND Data Administrators", role=GroupRole.Owner
+                    )
+                ],
+            ),
+        )
+        mock_gather_metadata.assert_called_once()
+        mock_update_docdb.assert_called_once()
+        mock_send_alert.assert_not_called()
+
+    @patch(
+        "aind_codeocean_pipeline_monitor.job.PipelineMonitorJob"
+        "._send_alert_to_teams"
+    )
+    @patch(
+        "aind_codeocean_pipeline_monitor.job.PipelineMonitorJob"
+        "._get_input_data_name"
+    )
+    @patch(
+        "aind_codeocean_pipeline_monitor.job.PipelineMonitorJob"
+        "._build_data_asset_params"
+    )
+    @patch(
+        "aind_codeocean_pipeline_monitor.job.PipelineMonitorJob"
+        "._wait_for_data_asset"
+    )
+    @patch(
+        "aind_codeocean_pipeline_monitor.job.PipelineMonitorJob"
+        "._monitor_pipeline"
+    )
+    @patch(
+        "aind_codeocean_pipeline_monitor.job.PipelineMonitorJob"
+        "._gather_metadata"
+    )
+    @patch("codeocean.data_asset.DataAssets.create_data_asset")
+    @patch("codeocean.computation.Computations.run_capsule")
+    @patch("aind_codeocean_pipeline_monitor.job.CodeOcean")
+    @patch(
+        "aind_codeocean_pipeline_monitor.job.PipelineMonitorJob._update_docdb"
+    )
+    @patch("aind_codeocean_pipeline_monitor.job.datetime")
+    def test_run_job_permissions_token(
+        self,
+        mock_datetime: MagicMock,
+        mock_update_docdb: MagicMock,
+        mock_permissions_client: MagicMock,
+        mock_run_capsule: MagicMock,
+        mock_create_data_asset: MagicMock,
+        mock_gather_metadata: MagicMock,
+        mock_monitor_pipeline: MagicMock,
+        mock_wait_for_data_asset: MagicMock,
+        mock_build_data_asset_params: MagicMock,
+        mock_get_input_data_name: MagicMock,
+        mock_send_alert: MagicMock,
+    ):
+        """Tests run_job method when a permissions token is set in the capture
+        settings.
+        """
+        mock_get_input_data_name.return_value = (
+            "ecephys_123456_2020-10-10_00-00-00"
+        )
+        mock_datetime.now.return_value = datetime(2020, 11, 10)
+        mock_run_capsule.return_value = Computation(
+            id="c123",
+            created=0,
+            name="c_name",
+            state=ComputationState.Initializing,
+            run_time=0,
+        )
+        mock_monitor_pipeline.return_value = Computation(
+            id="c123",
+            created=0,
+            name="c_name",
+            state=ComputationState.Completed,
+            run_time=100,
+        )
+        mock_gather_metadata.return_value = dict()
+
+        expected_name = (
+            "ecephys_123456_2020-10-10_00-00-00_processed_2020-11-10_00-00-00"
+        )
+        mock_create_data_asset.return_value = DataAsset(
+            id="def-123",
+            created=1,
+            name=expected_name,
+            mount=expected_name,
+            state=DataAssetState.Draft,
+            type=DataAssetType.Result,
+            last_used=1,
+            tags=["derived"],
+        )
+        mock_wait_for_data_asset.return_value = DataAsset(
+            id="def-123",
+            created=1,
+            name=expected_name,
+            mount=expected_name,
+            state=DataAssetState.Ready,
+            type=DataAssetType.Result,
+            last_used=1,
+            tags=["derived"],
+        )
+
+        mock_build_data_asset_params.return_value = DataAssetParams(
+            name=expected_name,
+            tags=["derived"],
+            mount=expected_name,
+            source=Source(
+                computation=ComputationSource(id="c123", path=None),
+            ),
+        )
+        with self.assertLogs(level="INFO") as captured:
+            self.capture_job_with_permissions_token.run_job()
+
+        self.assertEqual(8, len(captured.output))
+        mock_permissions_client.assert_called_once_with(
+            domain="test_domain",
+            token="permissions_token",
+            retries=0,
+        )
+        mock_update_permissions = (
+            mock_permissions_client.return_value.data_assets.update_permissions
+        )
         mock_update_permissions.assert_called_once_with(
             data_asset_id="def-123",
             permissions=Permissions(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 from codeocean.computation import RunParams
 from codeocean.data_asset import AWSS3Target, Target
-from pydantic import ValidationError
+from pydantic import SecretStr, ValidationError
 
 from aind_codeocean_pipeline_monitor.models import (
     CaptureSettings,
@@ -90,6 +90,14 @@ class TestsCapturedDataAssetParams(unittest.TestCase):
         self.assertTrue(
             expected_model_json, model.model_dump_json(exclude_none=True)
         )
+
+    def test_set_permissions_token(self):
+        """Test permissions token can be set"""
+        model = CaptureSettings(
+            tags=["derived, 123456, ecephys"],
+            permissions_token=SecretStr("token"),
+        )
+        self.assertEqual("token", model.permissions_token.get_secret_value())
 
 
 class TestsPipelineMonitorSettings(unittest.TestCase):


### PR DESCRIPTION
related to https://github.com/AllenNeuralDynamics/aind-co-pipeline-monitor-capsule/issues/46

Adds optional `permissions_token` field to the `CaptureSettings` model. If set, it will be used to create a new code ocean client for updating the captured result's permissions.