### PR TITLE
feat: add info to start and error alerts to teams

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dynamic = ["version"]
 dependencies = [
     'pydantic>=2.0',
     'pydantic_settings>=2.0',
-    'codeocean>=0.3.0',
+    'codeocean>=0.10.0',
 ]
 
 [project.optional-dependencies]

--- a/src/aind_codeocean_pipeline_monitor/job.py
+++ b/src/aind_codeocean_pipeline_monitor/job.py
@@ -151,8 +151,8 @@ class PipelineMonitorJob:
         response = requests.post(
             url=self.job_settings.alert_url, json=post_request_contents
         )
-        if response.status_code == 200:
-            logging.info(f"Alert response: {response.json()}")
+        if response.status_code == 200 or response.status_code == 202:
+            logging.info(f"Alert response: {response.text}")
         else:
             logging.warning(
                 f"There was an issue sending the alert: {response}"

--- a/src/aind_codeocean_pipeline_monitor/job.py
+++ b/src/aind_codeocean_pipeline_monitor/job.py
@@ -489,13 +489,15 @@ class PipelineMonitorJob:
                 f"Input data: {input_data_name}"
             )
             if self.job_settings.alert_url is not None:
-                message = (
-                    f"Starting {input_data_name} with "
-                    f"capsule_id {self.job_settings.run_params.capsule_id}, "
-                    f"pipeline_id {self.job_settings.run_params.pipeline_id}, "
-                    f"version {self.job_settings.run_params.version}"
+                message = f"Starting {input_data_name}"
+                extra_text = (
+                    f"- capsule: {self.job_settings.run_params.capsule_id}\n"
+                    f"- pipeline: {self.job_settings.run_params.pipeline_id}\n"
+                    f"- version: {self.job_settings.run_params.version}\n"
                 )
-                self._send_alert_to_teams(message=message)
+                self._send_alert_to_teams(
+                    message=message, extra_text=extra_text
+                )
 
             start_pipeline_response = self.client.computations.run_capsule(
                 self.job_settings.run_params

--- a/src/aind_codeocean_pipeline_monitor/job.py
+++ b/src/aind_codeocean_pipeline_monitor/job.py
@@ -489,7 +489,12 @@ class PipelineMonitorJob:
                 f"Input data: {input_data_name}"
             )
             if self.job_settings.alert_url is not None:
-                message = f"Starting {input_data_name}"
+                message = (
+                    f"Starting {input_data_name} with "
+                    f"capsule_id {self.job_settings.run_params.capsule_id}, "
+                    f"pipeline_id {self.job_settings.run_params.pipeline_id}, "
+                    f"version {self.job_settings.run_params.version}"
+                )
                 self._send_alert_to_teams(message=message)
 
             start_pipeline_response = self.client.computations.run_capsule(

--- a/src/aind_codeocean_pipeline_monitor/job.py
+++ b/src/aind_codeocean_pipeline_monitor/job.py
@@ -45,6 +45,7 @@ from codeocean.data_asset import (
     Source,
     Target,
 )
+from codeocean.error import Error
 
 from aind_codeocean_pipeline_monitor.models import PipelineMonitorSettings
 
@@ -561,10 +562,12 @@ class PipelineMonitorJob:
             if self.job_settings.alert_url is not None:
                 message = f"Finished {input_data_name}"
                 self._send_alert_to_teams(message=message)
-        except Exception as e:
+        except (Error, Exception) as e:
             if self.job_settings.alert_url is not None:
                 message = f"Error with {input_data_name}"
-                extra_text = f"Message: {e.args}"
+                extra_text = (
+                    str(e) if isinstance(e, Error) else f"Message: {e.args}"
+                )
                 self._send_alert_to_teams(
                     message=message, extra_text=extra_text
                 )

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1222,10 +1222,11 @@ class TestPipelineMonitorJob(unittest.TestCase):
         mock_send_alert.assert_has_calls(
             [
                 call(
-                    message=(
-                        "Starting ecephys_123456_2020-10-10_00-00-00 with "
-                        "capsule_id None, pipeline_id abc-123, version None"
-                    )
+                    message="Starting ecephys_123456_2020-10-10_00-00-00",
+                    extra_text=(
+                        "- capsule: None\n- pipeline: abc-123\n- version: "
+                        "None\n"
+                    ),
                 ),
                 call(message="Finished ecephys_123456_2020-10-10_00-00-00"),
             ]
@@ -1329,10 +1330,11 @@ class TestPipelineMonitorJob(unittest.TestCase):
         mock_send_alert.assert_has_calls(
             [
                 call(
-                    message=(
-                        "Starting ecephys_123456_2020-10-10_00-00-00 with "
-                        "capsule_id None, pipeline_id abc-123, version None"
-                    )
+                    message="Starting ecephys_123456_2020-10-10_00-00-00",
+                    extra_text=(
+                        "- capsule: None\n- pipeline: abc-123\n- version: "
+                        "None\n"
+                    ),
                 ),
                 call(
                     message="Error with ecephys_123456_2020-10-10_00-00-00",

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1221,7 +1221,12 @@ class TestPipelineMonitorJob(unittest.TestCase):
         self.assertEqual(9, len(captured.output))
         mock_send_alert.assert_has_calls(
             [
-                call(message="Starting ecephys_123456_2020-10-10_00-00-00"),
+                call(
+                    message=(
+                        "Starting ecephys_123456_2020-10-10_00-00-00 with "
+                        "capsule_id None, pipeline_id abc-123, version None"
+                    )
+                ),
                 call(message="Finished ecephys_123456_2020-10-10_00-00-00"),
             ]
         )
@@ -1323,7 +1328,12 @@ class TestPipelineMonitorJob(unittest.TestCase):
         self.assertEqual(2, len(captured.output))
         mock_send_alert.assert_has_calls(
             [
-                call(message="Starting ecephys_123456_2020-10-10_00-00-00"),
+                call(
+                    message=(
+                        "Starting ecephys_123456_2020-10-10_00-00-00 with "
+                        "capsule_id None, pipeline_id abc-123, version None"
+                    )
+                ),
                 call(
                     message="Error with ecephys_123456_2020-10-10_00-00-00",
                     extra_text="Message: ('Something went wrong.',)",

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -383,7 +383,7 @@ class TestPipelineMonitorJob(unittest.TestCase):
                 message="Job Success"
             )
         mock_post.assert_called_once()
-        expected_logs = ["INFO:root:Alert response: {'msg': 'good'}"]
+        expected_logs = ['INFO:root:Alert response: {"msg":"good"}']
         self.assertEqual(expected_logs, captured.output)
 
     @patch("requests.post")


### PR DESCRIPTION
closes #44 

- Updates "start" alert to include `capsule_id`, `pipeline_id`, and version from `run_params`
- Updates "error" alert to use latest `codeocean.error` error handling (from v.0.9.0) which includes error message and data

<img width="1022" height="516" alt="image" src="https://github.com/user-attachments/assets/67aa16ef-bd52-40d4-9c49-1f518ad2964a" />

<img width="972" height="431" alt="image" src="https://github.com/user-attachments/assets/d9287d81-23fa-4cbf-ac80-954eae95ba10" />

