### PR TITLE
chore: update reusable workflow reference in tag job 

### DIFF
--- a/.github/workflows/tag_and_publish.yml
+++ b/.github/workflows/tag_and_publish.yml
@@ -59,9 +59,9 @@ jobs:
         add: '["README.md"]'
   tag:
     needs: update_badges
-    uses: AllenNeuralDynamics/aind-github-actions/.github/workflows/tag.yml@main
+    uses: AllenNeuralDynamics/.github/.github/workflows/release-bump-version.yml@main
     secrets:
-      SERVICE_TOKEN: ${{ secrets.SERVICE_TOKEN }}
+      repo-token: ${{ secrets.SERVICE_TOKEN }}
   publish:
     needs: tag
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dynamic = ["version"]
 dependencies = [
     'pydantic>=2.0',
     'pydantic_settings>=2.0',
-    'codeocean>=0.10.0',
+    'codeocean>=0.10.0,<0.14.0',
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION

## Summary
We are deprecating `AllenNeuralDynamics/aind-github-actions` repo and are in the process of migrating to a new workflow. This PR updates the tag workflow references that point to the old workflow.

## Changes
- Updated workflow references from `AllenNeuralDynamics/aind-github-actions/.github/workflows/tag.yml@main` to `AllenNeuralDynamics/.github/.github/workflows/release-bump-version.yml@main`.
- Updated `SERVICE_TOKEN` to `repo-token`.
